### PR TITLE
Updated AWS Version and Fixed S3 error.

### DIFF
--- a/lib/connect-s3Store.js
+++ b/lib/connect-s3Store.js
@@ -42,9 +42,16 @@ module.exports = function (connect) {
 			Bucket: this.bucketName,
 			Key: 'sessions/' + sid
 		};
+		var obj = this;
 		this.client.getObject(getOptions, function (error, data) {
 			if(error) {
-				return callback(error.message);
+				if ((error.code||'') === 'NoSuchKey') {
+					return obj.set(sid, {}, function() {
+						callback();
+					});
+				} else {
+					return callback(error.message);
+				}
 			}
 			if(!data) {
 				return callback();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": ""
   },
   "dependencies": {
-    "aws-sdk": "~v1.4.1",
+    "aws-sdk": "^2.1.45",
     "debug": "~0.7.2"
   },
   "repository": {


### PR DESCRIPTION
Updated AWS Version to 2.1.45, and when S3 returning error "The specified key does not exist." create file in S3.
